### PR TITLE
Add personal information consent audit trail

### DIFF
--- a/src/main/java/io/virusafe/domain/entity/PersonalInformationConsentAction.java
+++ b/src/main/java/io/virusafe/domain/entity/PersonalInformationConsentAction.java
@@ -1,0 +1,9 @@
+package io.virusafe.domain.entity;
+
+/**
+ * Enum representing allowed personal information consent actions.
+ */
+public enum PersonalInformationConsentAction {
+    GRANTED,
+    REVOKED
+}

--- a/src/main/java/io/virusafe/domain/entity/PersonalInformationConsentAudit.java
+++ b/src/main/java/io/virusafe/domain/entity/PersonalInformationConsentAudit.java
@@ -1,0 +1,65 @@
+package io.virusafe.domain.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "personal_information_consent_audit")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@ToString
+public class PersonalInformationConsentAudit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Version
+    private Long version;
+
+    @EqualsAndHashCode.Include
+    private LocalDateTime changedOn;
+
+    @Enumerated(EnumType.STRING)
+    private PersonalInformationConsentAction action;
+
+    @EqualsAndHashCode.Include
+    private String userGuid;
+
+    /**
+     * All args constructor for PersonalInformationConsentAudit.
+     * Can be used as a Lombok builder.
+     *
+     * @param id        the entity's DB ID
+     * @param changedOn the time for this audit change
+     * @param action    the audit action
+     * @param userGuid  the user GUID for this personal information consent change
+     */
+    @Builder
+    public PersonalInformationConsentAudit(final Long id,
+                                           final LocalDateTime changedOn,
+                                           final PersonalInformationConsentAction action,
+                                           final String userGuid) {
+        this.id = id;
+        this.changedOn = changedOn;
+        this.action = action;
+        this.userGuid = userGuid;
+    }
+}

--- a/src/main/java/io/virusafe/repository/PersonalInformationConsentAuditRepository.java
+++ b/src/main/java/io/virusafe/repository/PersonalInformationConsentAuditRepository.java
@@ -1,0 +1,9 @@
+package io.virusafe.repository;
+
+import io.virusafe.domain.entity.PersonalInformationConsentAudit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PersonalInformationConsentAuditRepository extends JpaRepository<PersonalInformationConsentAudit, Long> {
+}

--- a/src/main/java/io/virusafe/service/audit/PersonalInformationConsentAuditService.java
+++ b/src/main/java/io/virusafe/service/audit/PersonalInformationConsentAuditService.java
@@ -1,0 +1,16 @@
+package io.virusafe.service.audit;
+
+import io.virusafe.domain.entity.PersonalInformationConsentAction;
+import io.virusafe.domain.entity.PersonalInformationConsentAudit;
+
+public interface PersonalInformationConsentAuditService {
+
+    /**
+     * Add a new personal information consent audit trail entry for the given user GUID.
+     *
+     * @param userGuid the user GUID to add an audit trail entry for
+     * @param action   the audit action type
+     * @return the new audit trail entry
+     */
+    PersonalInformationConsentAudit addAuditTrailEntry(String userGuid, PersonalInformationConsentAction action);
+}

--- a/src/main/java/io/virusafe/service/audit/PersonalInformationConsentAuditServiceImpl.java
+++ b/src/main/java/io/virusafe/service/audit/PersonalInformationConsentAuditServiceImpl.java
@@ -1,0 +1,45 @@
+package io.virusafe.service.audit;
+
+import io.virusafe.domain.entity.PersonalInformationConsentAction;
+import io.virusafe.domain.entity.PersonalInformationConsentAudit;
+import io.virusafe.repository.PersonalInformationConsentAuditRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+public class PersonalInformationConsentAuditServiceImpl implements PersonalInformationConsentAuditService {
+
+    private final PersonalInformationConsentAuditRepository personalInformationConsentAuditRepository;
+    private final Clock systemClock;
+
+    /**
+     * Construct a new PersonalInformationConsentAuditServiceImpl,
+     * using the autowired PersonalInformationConsentAuditRepository and system clock.
+     *
+     * @param personalInformationConsentAuditRepository the autowired PersonalInformationConsentAuditRepository bean to use for communicating with the DB
+     * @param systemClock                               the system clock to use for audit times
+     */
+    @Autowired
+    public PersonalInformationConsentAuditServiceImpl(final PersonalInformationConsentAuditRepository personalInformationConsentAuditRepository,
+                                                      final Clock systemClock) {
+        this.personalInformationConsentAuditRepository = personalInformationConsentAuditRepository;
+        this.systemClock = systemClock;
+    }
+
+    @Override
+    public PersonalInformationConsentAudit addAuditTrailEntry(final String userGuid,
+                                                              final PersonalInformationConsentAction action) {
+
+        PersonalInformationConsentAudit auditEntry = PersonalInformationConsentAudit.builder()
+                .action(action)
+                .changedOn(LocalDateTime.now(systemClock))
+                .userGuid(userGuid)
+                .build();
+        personalInformationConsentAuditRepository.save(auditEntry);
+
+        return auditEntry;
+    }
+}

--- a/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
+++ b/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
@@ -1,8 +1,10 @@
 package io.virusafe.service.userdetails;
 
 import io.virusafe.domain.command.PersonalInformationUpdateCommand;
+import io.virusafe.domain.entity.PersonalInformationConsentAction;
 import io.virusafe.domain.entity.UserDetails;
 import io.virusafe.repository.UserDetailsRepositoryFacade;
+import io.virusafe.service.audit.PersonalInformationConsentAuditService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,15 +24,19 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     private static final String MISSING_USER_TEMPLATE = "User with guid {0} is not registered!";
 
     private final UserDetailsRepositoryFacade userDetailsRepositoryFacade;
+    private final PersonalInformationConsentAuditService personalInformationConsentAuditService;
 
     /**
      * Construct a new UserDetailsService, using the autowired beans.
      *
      * @param userDetailsRepositoryFacade
+     * @param personalInformationConsentAuditService the PersonalInformationConsentAuditService to use for audit trail
      */
     @Autowired
-    public UserDetailsServiceImpl(final UserDetailsRepositoryFacade userDetailsRepositoryFacade) {
+    public UserDetailsServiceImpl(final UserDetailsRepositoryFacade userDetailsRepositoryFacade,
+                                  final PersonalInformationConsentAuditService personalInformationConsentAuditService) {
         this.userDetailsRepositoryFacade = userDetailsRepositoryFacade;
+        this.personalInformationConsentAuditService = personalInformationConsentAuditService;
     }
 
     @Override
@@ -69,6 +75,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         userDetails.setPreExistingConditions(personalInformationUpdateCommand.getPreExistingConditions());
 
         save(userDetails);
+        // Personal information is required here so we've also received consent.
+        personalInformationConsentAuditService.addAuditTrailEntry(userGuid, PersonalInformationConsentAction.GRANTED);
     }
 
     @Override
@@ -107,6 +115,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
                         .format(MISSING_USER_TEMPLATE, userGuid)));
         removeUserDetailsPersonalInfoFields(userDetails);
         save(userDetails);
+        // Deleting personal information so we've revoked the consent
+        personalInformationConsentAuditService.addAuditTrailEntry(userGuid, PersonalInformationConsentAction.REVOKED);
     }
 
     private void removeUserDetailsPersonalInfoFields(final UserDetails userDetails) {

--- a/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
+++ b/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
@@ -121,6 +121,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     private void removeUserDetailsPersonalInfoFields(final UserDetails userDetails) {
         userDetails.setIdentificationNumber(null);
+        userDetails.setIdentificationNumberPlain(null);
         userDetails.setAge(null);
         userDetails.setGender(null);
         userDetails.setPreExistingConditions(null);

--- a/src/main/resources/db/ddl/v2/v2_004_add_personal_information_audit_table.sql
+++ b/src/main/resources/db/ddl/v2/v2_004_add_personal_information_audit_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `personal_information_consent_audit` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `version` bigint(20) DEFAULT NULL,
+  `changed_on` DATETIME(6) NULL,
+  `action` varchar(32) NOT NULL,
+  `user_guid` varchar(40) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO `personal_information_consent_audit` (id, version, changed_on, action, user_guid)
+    SELECT null, null, NOW(), "GRANTED", `user_details`.`user_guid`
+    FROM `user_details` WHERE `identification_number` is not null;
+
+INSERT INTO `personal_information_consent_audit` (id, version, changed_on, action, user_guid)
+    SELECT null, null, NOW(), "REVOKED", `user_details`.`user_guid`
+    FROM `user_details` WHERE `identification_number` is null;

--- a/src/test/java/io/virusafe/service/audit/PersonalInformationConsentAuditServiceImplTest.java
+++ b/src/test/java/io/virusafe/service/audit/PersonalInformationConsentAuditServiceImplTest.java
@@ -1,0 +1,52 @@
+package io.virusafe.service.audit;
+
+import io.virusafe.domain.entity.PersonalInformationConsentAction;
+import io.virusafe.domain.entity.PersonalInformationConsentAudit;
+import io.virusafe.repository.PersonalInformationConsentAuditRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalInformationConsentAuditServiceImplTest {
+
+    private static final String USER_GUID = "USER_GUID";
+    private static final LocalDateTime CALCULATION_TIME = LocalDateTime.of(2020, 9, 5, 0, 0, 0, 0);
+    private Clock clock = Clock.fixed(
+            Instant.parse("2020-09-05T00:00:00.00Z"),
+            ZoneId.of("UTC")
+    );
+
+    @Mock
+    private PersonalInformationConsentAuditRepository personalInformationConsentAuditRepository;
+
+    private PersonalInformationConsentAuditServiceImpl personalInformationConsentAuditService;
+
+    @BeforeEach
+    public void setUp() {
+        personalInformationConsentAuditService = new PersonalInformationConsentAuditServiceImpl(
+                personalInformationConsentAuditRepository, clock);
+    }
+
+    @Test
+    public void testAddAuditTrailEntry() {
+        personalInformationConsentAuditService.addAuditTrailEntry(USER_GUID, PersonalInformationConsentAction.GRANTED);
+
+        PersonalInformationConsentAudit expectedAuditTrail = PersonalInformationConsentAudit.builder()
+                .userGuid(USER_GUID)
+                .action(PersonalInformationConsentAction.GRANTED)
+                .changedOn(CALCULATION_TIME)
+                .build();
+        verify(personalInformationConsentAuditRepository, times(1)).save(expectedAuditTrail);
+    }
+}

--- a/src/test/java/io/virusafe/service/userdetails/UserDetailsServiceImplTest.java
+++ b/src/test/java/io/virusafe/service/userdetails/UserDetailsServiceImplTest.java
@@ -5,6 +5,7 @@ import io.virusafe.domain.command.PersonalInformationUpdateCommand;
 import io.virusafe.domain.entity.RegistrationPin;
 import io.virusafe.domain.entity.UserDetails;
 import io.virusafe.repository.UserDetailsRepositoryFacade;
+import io.virusafe.service.audit.PersonalInformationConsentAuditService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,8 @@ class UserDetailsServiceImplTest {
     private final LocalDateTime timeNow = LocalDateTime.now(systemClock);
     @Mock
     private UserDetailsRepositoryFacade userDetailsRepositoryFacade;
+    @Mock
+    private PersonalInformationConsentAuditService personalInformationConsentAuditService;
 
     private UserDetailsServiceImpl userDetailsService;
 
@@ -54,7 +57,8 @@ class UserDetailsServiceImplTest {
 
     @BeforeEach
     public void setUp() {
-        this.userDetailsService = new UserDetailsServiceImpl(userDetailsRepositoryFacade);
+        this.userDetailsService = new UserDetailsServiceImpl(userDetailsRepositoryFacade,
+                personalInformationConsentAuditService);
     }
 
     @Test


### PR DESCRIPTION
Populated whenever we add/change/delete personal information.

Fixes #12

To test:
Add/change/remove personal information and verify the audit table has been updated properly with permission GRANTED/GRANTED/REVOKED, respectively.
 
PR submission checklist:

- [x] I have followed the [Contributing Guidelines](https://github.com/scalefocus/virusafe-backend/blob/master/CONTRIBUTING.md)
- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have described them above.
