### PR TITLE
add possibility to send push notifications based on inverted elastic …

### DIFF
--- a/PUSH-NOTIFICATIONS.md
+++ b/PUSH-NOTIFICATIONS.md
@@ -75,6 +75,9 @@ Overview:
       - answerQuery may include an operation - `and`/`or` with multiple subOperations. Along with describing the different criteria arguments, there is additional minMatch field which points the number of correct conditions that should be met.
       - polygonPoints includes a list of `lat`(latitude) and `lon`(longitude).
       
+      Optional parameters:
+      - reverseQueryResults boolean flag that add possibility to invert results from `questionnaireQuery`
+       
       Having these criteria set, there is a Elasticsearch query that is build and that returns a set of userGuids. Based on these userGuids there is additional search in the SQL database, where the push tokens are stored against the userGuids. These push tokens are used by Firebase when sending notifications.
 1. POST endpoint - `/admin/pushNotification/user`
     - input: RequstBody - CustomPushNotificationDTO

--- a/src/main/java/io/virusafe/controller/PushNotificationController.java
+++ b/src/main/java/io/virusafe/controller/PushNotificationController.java
@@ -53,7 +53,7 @@ public class PushNotificationController {
 
         pushNotificationService
                 .sendCustomPushNotifications(questionnaireQuery, pushNotificationRequestDTO.getMessage(),
-                        pushNotificationRequestDTO.getTitle());
+                        pushNotificationRequestDTO.getTitle(), pushNotificationRequestDTO.isReverseQueryResults());
     }
 
     /**

--- a/src/main/java/io/virusafe/domain/dto/CustomPushNotificationDTO.java
+++ b/src/main/java/io/virusafe/domain/dto/CustomPushNotificationDTO.java
@@ -17,7 +17,7 @@ public class CustomPushNotificationDTO {
     private Set<String> userGuids;
 
     @NotNull
-    @Size(max = 15)
+    @Size(max = 30)
     private String title;
 
     @NotNull

--- a/src/main/java/io/virusafe/domain/dto/PushNotificationRequestDTO.java
+++ b/src/main/java/io/virusafe/domain/dto/PushNotificationRequestDTO.java
@@ -24,4 +24,6 @@ public class PushNotificationRequestDTO {
     @NotNull
     @Size(max = 200)
     private String message;
+
+    private boolean reverseQueryResults;
 }

--- a/src/main/java/io/virusafe/domain/entity/UserDetails.java
+++ b/src/main/java/io/virusafe/domain/entity/UserDetails.java
@@ -121,7 +121,7 @@ public class UserDetails {
         if (Objects.nonNull(registrationPins)) {
             registrationPins.forEach(this::addRegistrationPin);
         }
-        this.createdDate = System.nanoTime();
+        this.createdDate = System.currentTimeMillis();
 
         this.tokenSecret = tokenSecret;
         this.refreshToken = refreshToken;

--- a/src/main/java/io/virusafe/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/virusafe/exception/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package io.virusafe.exception.handler;
 import io.jsonwebtoken.JwtException;
 import io.virusafe.exception.EncryptionProviderException;
 import io.virusafe.exception.InvalidPersonalInformationException;
+import io.virusafe.exception.PushNotificationException;
 import io.virusafe.exception.QueryExecuteException;
 import io.virusafe.exception.QueryParseException;
 import io.virusafe.exception.RateLimitTimeoutException;
@@ -270,6 +271,21 @@ public class GlobalExceptionHandler {
         ErrorDTO sanitizedErrorDTOO = ErrorDTO.builder().message(INVALID_QUERY_REQUEST_MESSAGE).build();
         logException(queryParseException);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(sanitizedErrorDTOO);
+    }
+
+    /**
+     * Reroute all Push Notification-related exceptions to HTTP 500.
+     *
+     * @param pushNotificationException the caught exception
+     * @return ResponseEntity of HTTP Status 500, containing error details
+     */
+    @ExceptionHandler({PushNotificationException.class})
+    public final ResponseEntity<ErrorDTO> handleJwtException(
+            final PushNotificationException pushNotificationException) {
+        logException(pushNotificationException);
+        ErrorDTO errorDTO = ErrorDTO.fromExceptionBuilder().exception(pushNotificationException).build();
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorDTO);
     }
 
     private List<String> filterExceptionStacktrace(final Exception exception) {

--- a/src/main/java/io/virusafe/repository/NoEncryptionUserDetailsRepositoryFacade.java
+++ b/src/main/java/io/virusafe/repository/NoEncryptionUserDetailsRepositoryFacade.java
@@ -49,10 +49,7 @@ public class NoEncryptionUserDetailsRepositoryFacade implements UserDetailsRepos
     }
 
     private Optional<UserDetails> decodeDetails(final Optional<UserDetails> userDetailsOpt) {
-        if (userDetailsOpt.isPresent()) {
-            return decode(userDetailsOpt.get());
-        }
-        return userDetailsOpt;
+        return userDetailsOpt.flatMap(this::decode);
     }
 
     @Override
@@ -71,7 +68,7 @@ public class NoEncryptionUserDetailsRepositoryFacade implements UserDetailsRepos
     }
 
     @Override
-    public Set<String> findAllPushTokensByUserGuid(final Set<String> userGuids) {
-        return userDetailsRepository.findAllPushTokensByUserGuid(userGuids);
+    public Set<String> findAllPushTokensByUserGuid(final Set<String> userGuids, final boolean reverse) {
+        return userDetailsRepository.findAllPushTokensByUserGuids(userGuids, reverse);
     }
 }

--- a/src/main/java/io/virusafe/repository/UserDetailsRepositoryFacade.java
+++ b/src/main/java/io/virusafe/repository/UserDetailsRepositoryFacade.java
@@ -55,5 +55,5 @@ public interface UserDetailsRepositoryFacade {
      *
      * @param userGuids userGuids to search for
      */
-    Set<String> findAllPushTokensByUserGuid(Set<String> userGuids);
+    Set<String> findAllPushTokensByUserGuid(Set<String> userGuids, final boolean reverse);
 }

--- a/src/main/java/io/virusafe/service/notification/PushNotificationSenderService.java
+++ b/src/main/java/io/virusafe/service/notification/PushNotificationSenderService.java
@@ -12,7 +12,8 @@ public interface PushNotificationSenderService {
      * @return
      */
     void sendCustomPushNotifications(final QuestionnaireQuery questionnaireQuery, final String title,
-                                     final String message);
+                                     final String message, final boolean reverseQueryResults);
+
     /**
      * sends custom push notifications for concrete users
      *

--- a/src/main/java/io/virusafe/service/userdetails/UserDetailsService.java
+++ b/src/main/java/io/virusafe/service/userdetails/UserDetailsService.java
@@ -91,5 +91,5 @@ public interface UserDetailsService {
      *
      * @return
      */
-    Set<String> findPushTokensForUserGuids(final Set<String> userGuids);
+    Set<String> findPushTokensForUserGuids(final Set<String> userGuids, final boolean reverseQueryResults);
 }

--- a/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
+++ b/src/main/java/io/virusafe/service/userdetails/UserDetailsServiceImpl.java
@@ -128,8 +128,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     }
 
     @Override
-    public Set<String> findPushTokensForUserGuids(final Set<String> userGuids) {
-        Set<String> guids = userDetailsRepositoryFacade.findAllPushTokensByUserGuid(userGuids);
+    public Set<String> findPushTokensForUserGuids(final Set<String> userGuids, final boolean reverse) {
+        Set<String> guids = userDetailsRepositoryFacade.findAllPushTokensByUserGuid(userGuids, reverse);
         return guids.stream().filter(Predicate.not(Objects::isNull))
                 .filter(Predicate.not(String::isEmpty)).collect(Collectors.toSet());
     }

--- a/src/test/java/io/virusafe/repository/EncryptionUserDetailsRepositoryFacadeTest.java
+++ b/src/test/java/io/virusafe/repository/EncryptionUserDetailsRepositoryFacadeTest.java
@@ -12,6 +12,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,6 +33,7 @@ class EncryptionUserDetailsRepositoryFacadeTest {
     private static final String PIN = "PIN";
     private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
     private static final String IV_VECTOR = "IV_VECTOR";
+    private static final String PUSH_TOKEN = "PUSH_TOKEN";
     @Mock
     private UserDetailsRepository userDetailsRepository;
     @Mock
@@ -197,5 +199,12 @@ class EncryptionUserDetailsRepositoryFacadeTest {
                 .build();
         repositoryFacade.save(userDetails);
         verify(userDetailsRepository, times(1)).save(expectedUserDetails);
+    }
+
+    @Test
+    public void testFindAllPushTokensByUserGuid() {
+        when(userDetailsRepository.findAllPushTokensByUserGuids(Set.of(USER_GUID), true)).thenReturn(Set.of(PUSH_TOKEN));
+        repositoryFacade.findAllPushTokensByUserGuid(Set.of(USER_GUID), true);
+        verify(userDetailsRepository, times(1)).findAllPushTokensByUserGuids(Set.of(USER_GUID), true);
     }
 }

--- a/src/test/java/io/virusafe/repository/NoEncryptionUserDetailsRepositoryFacadeTest.java
+++ b/src/test/java/io/virusafe/repository/NoEncryptionUserDetailsRepositoryFacadeTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +29,7 @@ class NoEncryptionUserDetailsRepositoryFacadeTest {
     private static final String PHONE_NUMBER = "PHONE_NUMBER";
     private static final String PIN = "PIN";
     private static final String REFRESH_TOKEN = "REFRESH_TOKEN";
+    private static final String PUSH_TOKEN = "PUSH_TOKEN";
     @Mock
     private UserDetailsRepository userDetailsRepository;
 
@@ -128,5 +130,19 @@ class NoEncryptionUserDetailsRepositoryFacadeTest {
                 .build();
         repositoryFacade.save(userDetails);
         verify(userDetailsRepository, times(1)).save(expectedUserDetails);
+    }
+
+    @Test
+    public void testFindAllPushTokensByUserGuid() {
+        when(userDetailsRepository.findAllPushTokensByUserGuids(Set.of(USER_GUID), true)).thenReturn(Set.of(PUSH_TOKEN));
+        repositoryFacade.findAllPushTokensByUserGuid(Set.of(USER_GUID), true);
+        verify(userDetailsRepository, times(1)).findAllPushTokensByUserGuids(Set.of(USER_GUID), true);
+    }
+
+    @Test
+    public void testFindAllPushTokensByUserGuidReversed() {
+        when(userDetailsRepository.findAllPushTokensByUserGuids(Set.of(USER_GUID), false)).thenReturn(Set.of(PUSH_TOKEN));
+        repositoryFacade.findAllPushTokensByUserGuid(Set.of(USER_GUID), false);
+        verify(userDetailsRepository, times(1)).findAllPushTokensByUserGuids(Set.of(USER_GUID), false);
     }
 }

--- a/src/test/java/io/virusafe/repository/UserDetailsRepositoryTest.java
+++ b/src/test/java/io/virusafe/repository/UserDetailsRepositoryTest.java
@@ -1,23 +1,46 @@
 package io.virusafe.repository;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Profile;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.junit.jupiter.api.Test;
 
-@ExtendWith(SpringExtension.class)
-@DataJpaTest
-@Profile("test")
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 public class UserDetailsRepositoryTest {
-
-/*    @Autowired
-    private UserDetailsRepository userDetailsRepository;
+    private final static String PUSH_TOKEN_1 = "token1";
+    private final static String PUSH_TOKEN_2 = "token2";
+    private static final String USER_GUID = "userGUID";
 
     @Test
-    public void findAllPushTokensByUserGuidTest() {
-        Set<String> userGuids = new HashSet<>();
-        userGuids.add("a72c7397-733c-11ea-bbcc-f60659fdf23c");
-        Set<String> allPushTokensByUserGuid = userDetailsRepository.findAllPushTokensByUserGuid(userGuids);
-        System.out.println(allPushTokensByUserGuid);
-    }*/
+    void findAllPushTokensByUserGuids_AllTokens() {
+        UserDetailsRepository repository = spy(UserDetailsRepository.class);
+        when(repository.findAllPushTokens()).thenReturn(Set.of(PUSH_TOKEN_1, PUSH_TOKEN_2));
+        Set<String> allTokens = repository.findAllPushTokensByUserGuids(Collections.emptySet(), true);
+        assertNotNull(allTokens);
+        assertEquals(2, allTokens.size());
+    }
+
+    @Test
+    void findAllPushTokensByUserGuids_In() {
+        UserDetailsRepository repository = spy(UserDetailsRepository.class);
+        when(repository.findAllPushTokensByUserGuidIn(anySet())).thenReturn(Set.of(PUSH_TOKEN_1));
+        Set<String> allTokens = repository.findAllPushTokensByUserGuids(Set.of(USER_GUID), false);
+        assertNotNull(allTokens);
+        assertEquals(1, allTokens.size());
+    }
+
+    @Test
+    void findAllPushTokensByUserGuids_NotIn() {
+        UserDetailsRepository repository = spy(UserDetailsRepository.class);
+        when(repository.findAllPushTokensByUserGuidNotIn(anySet())).thenReturn(Set.of(PUSH_TOKEN_2));
+        Set<String> allTokens = repository.findAllPushTokensByUserGuids(Set.of(USER_GUID), true);
+        assertNotNull(allTokens);
+        assertEquals(1, allTokens.size());
+    }
+
 }

--- a/src/test/java/io/virusafe/service/notification/PushNotificationSenderServiceTest.java
+++ b/src/test/java/io/virusafe/service/notification/PushNotificationSenderServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,6 +28,7 @@ public class PushNotificationSenderServiceTest {
     private static final String MESSAGE = "Please send your questionnaire today.";
     private static final String TITLE = "title";
     private static final String TEST_USER_GUID = "testUserGuid";
+    private static final String TEST_PUSH_TOKEN = "testPushToken";
 
     @Mock
     private UserDetailsService userDetailsService;
@@ -51,10 +53,11 @@ public class PushNotificationSenderServiceTest {
 
         when(questionnaireQueryService.searchInQuestionnaire(mockQuestionnaireQuery))
                 .thenReturn(Set.of(TEST_USER_GUID));
-        when(userDetailsService.findPushTokensForUserGuids(any())).thenReturn(Set.of(TEST_USER_GUID));
-        pushNotificationSenderService.sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE);
+        when(userDetailsService.findPushTokensForUserGuids(Set.of(TEST_USER_GUID), true)).thenReturn(Set.of(TEST_PUSH_TOKEN));
+        pushNotificationSenderService.sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE, true);
         verify(questionnaireQueryService, times(1)).searchInQuestionnaire(mockQuestionnaireQuery);
-        verify(userDetailsService, times(1)).findPushTokensForUserGuids(any());
+        verify(userDetailsService, times(1)).findPushTokensForUserGuids(Set.of(TEST_USER_GUID), true);
+        verify(pushNotificationService, times(1)).sendNotificationToTokens(any(), any());
     }
 
     @Test
@@ -64,7 +67,7 @@ public class PushNotificationSenderServiceTest {
         when(questionnaireQueryService.searchInQuestionnaire(mockQuestionnaireQuery))
                 .thenReturn(emptySet());
         assertThrows(PushNotificationException.class, () ->
-                pushNotificationSenderService.sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE));
+                pushNotificationSenderService.sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE, false));
     }
 
     @Test
@@ -73,8 +76,28 @@ public class PushNotificationSenderServiceTest {
 
         when(questionnaireQueryService.searchInQuestionnaire(mockQuestionnaireQuery))
                 .thenReturn(Set.of(TEST_USER_GUID));
-        when(userDetailsService.findPushTokensForUserGuids(any())).thenReturn(emptySet());
+        when(userDetailsService.findPushTokensForUserGuids(Set.of(TEST_USER_GUID), true)).thenReturn(emptySet());
         assertThrows(PushNotificationException.class, () -> pushNotificationSenderService
-                .sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE));
+                .sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE, true));
+    }
+
+    @Test
+    public void sendCustomPushNotificationsTest_searchInQuestionnaireEmptySetButNotIn() {
+        QuestionnaireQuery mockQuestionnaireQuery = mock(QuestionnaireQuery.class);
+
+        when(questionnaireQueryService.searchInQuestionnaire(mockQuestionnaireQuery)).thenReturn(emptySet());
+        when(userDetailsService.findPushTokensForUserGuids(emptySet(), true)).thenReturn(Set.of(TEST_PUSH_TOKEN));
+        doThrow(PushNotificationException.class).when(pushNotificationService).sendNotificationToTokens(any(), any());
+        assertThrows(PushNotificationException.class, () -> pushNotificationSenderService
+                .sendCustomPushNotifications(mockQuestionnaireQuery, TITLE, MESSAGE, true));
+    }
+
+    @Test
+    public void sendCustomNotificationsToConcreteUsersTest() {
+        when(userDetailsService.findPushTokensForUserGuids(Set.of(TEST_USER_GUID), false)).thenReturn(Set.of(TEST_USER_GUID));
+        pushNotificationSenderService.sendNotificationsForConcreteUsers(Set.of(TEST_USER_GUID), TITLE, MESSAGE);
+
+        verify(userDetailsService, times(1)).findPushTokensForUserGuids(Set.of(TEST_USER_GUID), false);
+        verify(pushNotificationService, times(1)).sendNotificationToTokens(any(), any());
     }
 }


### PR DESCRIPTION
Fixes #17 

To test:
try to send notifications to people with reverse query flag set to true

PR submission checklist:

- [X] I have followed the [Contributing Guidelines](https://github.com/scalefocus/virusafe-backend/blob/master/CONTRIBUTING.md)
- [ ] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have described them above.
